### PR TITLE
Fix typo in GoogleAdsClient

### DIFF
--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -144,7 +144,7 @@ module Google
               # If there is an underlying GoogleAdsFailure, throw that one.
               if detail.is_a?(
                   Google::Ads::GoogleAds::V0::Errors::GoogleAdsFailure)
-                raise Google::Ads::GooglAads::Errors::GoogleAdsError.new(
+                raise Google::Ads::GoogleAds::Errors::GoogleAdsError.new(
                     detail)
               end
               if detail.is_a?(Google::Protobuf::Any)


### PR DESCRIPTION
### What?

When attempting to run [this example](https://github.com/googleads/google-ads-ruby/blob/85eff72797e0c1a9a7d557366de6932c869affb1/examples/account_management/get_account_information.rb), the following error is raised:

```
NameError (uninitialized constant Google::Ads::GooglAads)
```

In [`Google::Ads::GoogleAds::GoogleAdsClient`](https://github.com/googleads/google-ads-ruby/blob/a8553de62943608850bdcec58208e80d20d56e94/lib/google/ads/google_ads/google_ads_client.rb#L147), `Google::Ads::GoogleAds` is misspelled as `Google::Ads::GooglAads`.

This PR fixes this typo.

### Related issues

- https://github.com/googleads/google-ads-ruby/issues/10