### PR TITLE
Relax pin to allow bundler 2.

### DIFF
--- a/google-ads-googleads.gemspec
+++ b/google-ads-googleads.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'google-gax', '~> 1.4'
 
-  s.add_development_dependency 'bundler', '~> 1.9'
+  s.add_development_dependency 'bundler', ["> 1.9", "< 3"]
   s.add_development_dependency 'rake', '~> 11.3'
 
   s.add_development_dependency 'minitest', '~> 5.10'


### PR DESCRIPTION
Bundler 2 has been released, nothing in our `Gemfile` prevents this project from working with both versions of bundler, and we haven't committed `Gemfile.lock` (which is fine because this is a library and not an application). This commit relaxes the gemspec pin on bundler to allow installs with bundler 2, but will not automatically add bundler 3 (should they ever release that).