### PR TITLE
Use `options.fetch(:customer_id).tr("-", "")` in all examples

### DIFF
--- a/examples/account_management/get_account_information.rb
+++ b/examples/account_management/get_account_information.rb
@@ -76,7 +76,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    get_account_information(options[:customer_id])
+    get_account_information(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/advanced_operations/add_ad_group_bid_modifier.rb
+++ b/examples/advanced_operations/add_ad_group_bid_modifier.rb
@@ -102,7 +102,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_ad_group_bid_modifier(options[:customer_id],
+    add_ad_group_bid_modifier(options.fetch(:customer_id).tr("-", ""),
         options[:ad_group_id], options[:bid_modifier_value])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/advanced_operations/add_expanded_text_ad_with_upgraded_urls.rb
+++ b/examples/advanced_operations/add_expanded_text_ad_with_upgraded_urls.rb
@@ -123,7 +123,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_expanded_text_ad_with_upgraded_urls(options[:customer_id],
+    add_expanded_text_ad_with_upgraded_urls(options.fetch(:customer_id).tr("-", ""),
         options[:ad_group_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/advanced_operations/create_and_attach_shared_keyword_set.rb
+++ b/examples/advanced_operations/create_and_attach_shared_keyword_set.rb
@@ -127,7 +127,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    create_and_attach_shared_keyword_set(options[:customer_id],
+    create_and_attach_shared_keyword_set(options.fetch(:customer_id).tr("-", ""),
         options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|

--- a/examples/advanced_operations/find_and_remove_criteria_from_shared_set.rb
+++ b/examples/advanced_operations/find_and_remove_criteria_from_shared_set.rb
@@ -131,7 +131,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    find_and_remove_criteria_from_shared_set(options[:customer_id],
+    find_and_remove_criteria_from_shared_set(options.fetch(:customer_id).tr("-", ""),
         options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|

--- a/examples/advanced_operations/get_ad_group_bid_modifiers.rb
+++ b/examples/advanced_operations/get_ad_group_bid_modifiers.rb
@@ -107,7 +107,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_ad_group_bid_modifiers(options[:customer_id], options[:ad_group_id])
+    get_ad_group_bid_modifiers(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|
         STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/advanced_operations/use_portfolio_bidding_strategy.rb
+++ b/examples/advanced_operations/use_portfolio_bidding_strategy.rb
@@ -118,7 +118,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    use_portfolio_bidding_strategy(options[:customer_id])
+    use_portfolio_bidding_strategy(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/add_ad_groups.rb
+++ b/examples/basic_operations/add_ad_groups.rb
@@ -86,7 +86,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_ad_groups(options[:customer_id], options[:campaign_id])
+    add_ad_groups(options.fetch(:customer_id).tr("-", ""), options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/add_campaigns.rb
+++ b/examples/basic_operations/add_campaigns.rb
@@ -117,7 +117,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_campaigns(options[:customer_id])
+    add_campaigns(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/add_expanded_text_ads.rb
+++ b/examples/basic_operations/add_expanded_text_ads.rb
@@ -96,7 +96,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_expanded_text_ads(options[:customer_id], options[:ad_group_id])
+    add_expanded_text_ads(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/add_keyword.rb
+++ b/examples/basic_operations/add_keyword.rb
@@ -95,7 +95,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    add_keyword(options[:customer_id], options[:ad_group_id], options[:keyword])
+    add_keyword(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id], options[:keyword])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/get_ad_groups.rb
+++ b/examples/basic_operations/get_ad_groups.rb
@@ -89,7 +89,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_ad_groups(options[:customer_id], options[:campaign_id])
+    get_ad_groups(options.fetch(:customer_id).tr("-", ""), options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/get_campaigns.rb
+++ b/examples/basic_operations/get_campaigns.rb
@@ -71,7 +71,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_campaigns(options[:customer_id])
+    get_campaigns(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/get_expanded_text_ads.rb
+++ b/examples/basic_operations/get_expanded_text_ads.rb
@@ -105,7 +105,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_expanded_text_ads(options[:customer_id], options[:ad_group_id])
+    get_expanded_text_ads(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/get_keywords.rb
+++ b/examples/basic_operations/get_keywords.rb
@@ -102,7 +102,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_keywords(options[:customer_id], options[:ad_group_id])
+    get_keywords(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/pause_ad.rb
+++ b/examples/basic_operations/pause_ad.rb
@@ -85,7 +85,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    pause_ad(options[:customer_id], options[:ad_group_id], options[:ad_id])
+    pause_ad(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id], options[:ad_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/remove_ad.rb
+++ b/examples/basic_operations/remove_ad.rb
@@ -76,7 +76,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    remove_ad(options[:customer_id], options[:ad_group_id], options[:ad_id])
+    remove_ad(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id], options[:ad_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/remove_ad_group.rb
+++ b/examples/basic_operations/remove_ad_group.rb
@@ -73,7 +73,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    remove_ad_group(options[:customer_id], options[:ad_group_id])
+    remove_ad_group(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/remove_campaign.rb
+++ b/examples/basic_operations/remove_campaign.rb
@@ -74,7 +74,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    remove_campaign(options[:customer_id], options[:campaign_id])
+    remove_campaign(options.fetch(:customer_id).tr("-", ""), options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/remove_keyword.rb
+++ b/examples/basic_operations/remove_keyword.rb
@@ -80,7 +80,7 @@ if __FILE__ == $PROGRAM_NAME
 
   begin
     remove_keyword(
-        options[:customer_id], options[:ad_group_id], options[:criteria_id])
+        options.fetch(:customer_id).tr("-", ""), options[:ad_group_id], options[:criteria_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|
         STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/update_ad_group.rb
+++ b/examples/basic_operations/update_ad_group.rb
@@ -91,7 +91,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    update_ad_group(options[:customer_id], options[:ad_group_id],
+    update_ad_group(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id],
         options[:bid_micro_amount])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/basic_operations/update_campaign.rb
+++ b/examples/basic_operations/update_campaign.rb
@@ -85,7 +85,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    update_campaign(options[:customer_id], options[:campaign_id])
+    update_campaign(options.fetch(:customer_id).tr("-", ""), options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/basic_operations/update_keyword.rb
+++ b/examples/basic_operations/update_keyword.rb
@@ -92,7 +92,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    update_keyword(options[:customer_id], options[:ad_group_id],
+    update_keyword(options.fetch(:customer_id).tr("-", ""), options[:ad_group_id],
         options[:criteria_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/billing/add_account_budget_proposal.rb
+++ b/examples/billing/add_account_budget_proposal.rb
@@ -110,7 +110,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_account_budget_proposal(options[:customer_id],
+    add_account_budget_proposal(options.fetch(:customer_id).tr("-", ""),
         options[:billing_setup_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|

--- a/examples/billing/get_account_budget_proposals.rb
+++ b/examples/billing/get_account_budget_proposals.rb
@@ -106,7 +106,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_account_budget_proposals(options[:customer_id])
+    get_account_budget_proposals(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/billing/get_account_budgets.rb
+++ b/examples/billing/get_account_budgets.rb
@@ -144,7 +144,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_account_budgets(options[:customer_id])
+    get_account_budgets(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/billing/get_billing_setup.rb
+++ b/examples/billing/get_billing_setup.rb
@@ -101,7 +101,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_billing_setup(options[:customer_id])
+    get_billing_setup(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/billing/remove_billing_example.rb
+++ b/examples/billing/remove_billing_example.rb
@@ -74,7 +74,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    remove_billing_setups(options[:customer_id], options[:billing_setup_id])
+    remove_billing_setups(options.fetch(:customer_id).tr("-", ""), options[:billing_setup_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/campaign_management/add_campaign_bid_modifier.rb
+++ b/examples/campaign_management/add_campaign_bid_modifier.rb
@@ -102,7 +102,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_campaign_bid_modifier(options[:customer_id],
+    add_campaign_bid_modifier(options.fetch(:customer_id).tr("-", ""),
         options[:campaign_id], options[:bid_modifier])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/campaign_management/get_all_disapproved_ads.rb
+++ b/examples/campaign_management/get_all_disapproved_ads.rb
@@ -121,7 +121,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_all_disapproved_ads(options[:customer_id], options[:campaign_id])
+    get_all_disapproved_ads(options.fetch(:customer_id).tr("-", ""), options[:campaign_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/hotel_ads/add_hotel_ad.rb
+++ b/examples/hotel_ads/add_hotel_ad.rb
@@ -241,7 +241,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_hotel_ads(options[:customer_id], options[:hotel_center_account_id],
+    add_hotel_ads(options.fetch(:customer_id).tr("-", ""), options[:hotel_center_account_id],
         options[:cpc_bid_ceiling_micro_amount])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|

--- a/examples/hotel_ads/add_hotel_ad_group_bid_modifiers.rb
+++ b/examples/hotel_ads/add_hotel_ad_group_bid_modifiers.rb
@@ -125,7 +125,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_hotel_ad_group_bid_modifiers(options[:customer_id],
+    add_hotel_ad_group_bid_modifiers(options.fetch(:customer_id).tr("-", ""),
         options[:ad_group_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|

--- a/examples/recommendations/apply_recommendation.rb
+++ b/examples/recommendations/apply_recommendation.rb
@@ -97,7 +97,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    apply_recommendation(options[:customer_id], options[:recommendation_id])
+    apply_recommendation(options.fetch(:customer_id).tr("-", ""), options[:recommendation_id])
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/recommendations/get_text_ad_recommendations.rb
+++ b/examples/recommendations/get_text_ad_recommendations.rb
@@ -94,7 +94,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    get_text_ad_recommendations(options[:customer_id])
+    get_text_ad_recommendations(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/remarketing/add_conversion_action.rb
+++ b/examples/remarketing/add_conversion_action.rb
@@ -86,7 +86,7 @@ if __FILE__ == $0
   end.parse!
 
   begin
-    add_conversion_action(options[:customer_id])
+    add_conversion_action(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/reporting/get_hotel_ads_performance.rb
+++ b/examples/reporting/get_hotel_ads_performance.rb
@@ -108,7 +108,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    get_hotel_ads_performance(options[:customer_id])
+    get_hotel_ads_performance(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/reporting/get_keyword_stats.rb
+++ b/examples/reporting/get_keyword_stats.rb
@@ -115,7 +115,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    get_keyword_stats(options[:customer_id])
+    get_keyword_stats(options.fetch(:customer_id).tr("-", ""))
   rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
     e.failure.errors.each do |error|
       STDERR.printf("Error with message: %s\n", error.message)

--- a/examples/targeting/add_campaign_targeting_criteria.rb
+++ b/examples/targeting/add_campaign_targeting_criteria.rb
@@ -142,7 +142,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    add_campaign_targeting_criteria(options[:customer_id],
+    add_campaign_targeting_criteria(options.fetch(:customer_id).tr("-", ""),
         options[:campaign_id], options[:keyword], options[:location_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|

--- a/examples/targeting/get_campaign_targeting_criteria.rb
+++ b/examples/targeting/get_campaign_targeting_criteria.rb
@@ -99,7 +99,7 @@ if __FILE__ == $PROGRAM_NAME
   end.parse!
 
   begin
-    get_campaign_targeting_criteria(options[:customer_id],
+    get_campaign_targeting_criteria(options.fetch(:customer_id).tr("-", ""),
         options[:campaign_id])
     rescue Google::Ads::GoogleAds::Errors::GoogleAdsError => e
       e.failure.errors.each do |error|


### PR DESCRIPTION
In #43 I added an [example](https://git.io/fjfRI) which used
`Hash#fetch` and `String#tr` to improve the handling of customer ID command
options. Here I just used `sed` to replace every `options[:customer_id]`
with `options.fetch(:customer_id).tr("-", "")` to use that consistently
in all our examples.