### PR TITLE
Add tests around the logging interceptor

### DIFF
--- a/lib/google/ads/google_ads/logging_interceptor.rb
+++ b/lib/google/ads/google_ads/logging_interceptor.rb
@@ -16,8 +16,7 @@
 #
 # Interceptor to log outgoing requests and incoming responses.
 
-require 'google/ads/google_ads/v1/errors/errors_pb'
-require 'google/ads/google_ads/v0/errors/errors_pb'
+require 'google/ads/google_ads'
 require 'grpc/generic/interceptors'
 require 'json'
 
@@ -25,10 +24,10 @@ module Google
   module Ads
     module GoogleAds
       class LoggingInterceptor < GRPC::ClientInterceptor
-        INTERESTING_ERROR_CLASSES = [
-          Google::Ads::GoogleAds::V0::Errors::GoogleAdsFailure,
-          Google::Ads::GoogleAds::V1::Errors::GoogleAdsFailure,
-        ].freeze
+        INTERESTING_ERROR_CLASSES = ::Google::Ads::GoogleAds::KNOWN_API_VERSIONS.map { |v|
+          require "google/ads/google_ads/#{v.downcase}/errors/errors_pb"
+          const_get("Google::Ads::GoogleAds::#{v}::Errors::GoogleAdsFailure")
+        }
 
         def initialize(logger)
           super()

--- a/test/test_logging_interceptor.rb
+++ b/test/test_logging_interceptor.rb
@@ -24,12 +24,149 @@ require 'google/ads/google_ads/logging_interceptor'
 require 'google/ads/google_ads/v1/services/media_file_service_services_pb'
 
 class TestLoggingInterceptor < Minitest::Test
+  attr_reader :sio
+  attr_reader :logger
+  attr_reader :li
+
+  def setup
+    @sio = StringIO.new
+    @logger = Logger.new(sio)
+    @li = Google::Ads::GoogleAds::LoggingInterceptor.new(logger)
+  end
+
+  def test_logging_interceptor_logs_na_customer_id_with_missing_customer_id
+    li.request_response(
+      request: make_request_with_no_customer_id,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "CID: N/A")
+  end
+
+  def test_logging_interceptor_logs_customer_id
+    customer_id = "123"
+    li.request_response(
+      request: make_request(customer_id: customer_id),
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "CID: #{customer_id}")
+  end
+
+  def test_logging_interceptor_logs_host
+    host = "example.com"
+    li.request_response(
+      request: make_request,
+      call: make_fake_call(host: host),
+      method: :doesnt_matter,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "Host: #{host}")
+  end
+
+  def test_logging_interceptor_logs_method
+    method = :method
+    li.request_response(
+      request: make_request,
+      call: make_fake_call,
+      method: method,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "Method: #{method}")
+  end
+
+  def test_logging_interceptor_inspects_request
+    li.request_response(
+      request: make_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "Google::Ads::GoogleAds::V1::Services::MutateMediaFilesRequest")
+  end
+
+  def test_logging_interceptor_logs_isfault_no
+    li.request_response(
+      request: make_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "IsFault: no")
+  end
+
+  def test_logging_interceptor_logs_isfault_yes_when_call_explodes
+    li.request_response(
+      request: make_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+      raise "boom"
+    end
+  rescue Exception => e
+    if e.message != "boom"
+      raise
+    end
+
+    sio.rewind
+    assert_includes(sio.read, "IsFault: yes")
+  end
+
+  def test_logging_interceptor_logs_response
+    li.request_response(
+      request: make_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+      Google::Protobuf::StringValue.new(value: "some data")
+    end
+
+    sio.rewind
+    assert_includes(sio.read, JSON.dump("some data"))
+  end
+
+  def test_logging_interceptor_logs_some_error_details_if_v0_error
+    li.request_response(
+      request: make_small_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+      raise make_realistic_error("v0")
+    end
+  rescue GRPC::InvalidArgument
+    sio.rewind
+    assert_includes(sio.read, "INVALID_CUSTOMER_ID")
+  end
+
+  def test_logging_interceptor_logs_some_error_details_if_v1_error
+    li.request_response(
+      request: make_small_request,
+      call: make_fake_call,
+      method: :doesnt_matter,
+    ) do
+      raise make_realistic_error("v1")
+    end
+  rescue GRPC::InvalidArgument
+    sio.rewind
+    assert_includes(sio.read, "INVALID_CUSTOMER_ID")
+  end
+
   def test_logging_interceptor_can_serialize_images
     # this test segfaults the ruby virtual machine before c26ae44
-    sio = StringIO.new
-    logger = Logger.new(sio)
-    li = Google::Ads::GoogleAds::LoggingInterceptor.new(logger)
-
     li.request_response(
       request: make_request,
       call: make_fake_call,
@@ -38,17 +175,55 @@ class TestLoggingInterceptor < Minitest::Test
     end
   end
 
-  def make_fake_call
+  def make_fake_call(host: "peer")
     Class.new do
-      def initialize
-        @wrapped = Struct.new(:peer).new("peer")
+      def initialize(host)
+        @wrapped = Struct.new(:peer).new(host)
       end
-    end.new
+    end.new(host)
   end
 
-  def make_request
+  def make_request_with_no_customer_id
+    # this can be literally any protobuf type, because the class's descriptor
+    # is the only method we cal
+    Google::Protobuf::StringValue.new(value: "bees")
+  end
+
+  def make_small_request(customer_id: "123")
     Google::Ads::GoogleAds::V1::Services::MutateMediaFilesRequest.new(
-      customer_id: "123123123",
+      customer_id: customer_id,
+      operations: [
+        Google::Ads::GoogleAds::V1::Services::MediaFileOperation.new(
+          create: Google::Ads::GoogleAds::V1::Resources::MediaFile.new(
+            image: Google::Ads::GoogleAds::V1::Resources::MediaImage.new(
+              data: Google::Protobuf::BytesValue.new(
+                value: File.open("test/fixtures/sam.jpg", "rb").read[0..10]
+              )
+            )
+          )
+        )
+      ]
+    )
+  end
+
+  def make_realistic_error(version)
+    GRPC::InvalidArgument.new(
+      "bees",
+      make_error_metadata(version),
+    )
+  end
+
+  def make_error_metadata(version)
+    {
+      "google.rpc.debuginfo-bin" => "\x12\xA9\x02[ORIGINAL ERROR] generic::invalid_argument: Invalid customer ID 'INSERT_CUSTOMER_ID_HERE'. [google.rpc.error_details_ext] { details { type_url: \"type.googleapis.com/google.ads.googleads.v1.errors.GoogleAdsFailure\" value: \"\\n4\\n\\002\\010\\020\\022.Invalid customer ID \\'INSERT_CUSTOMER_ID_HERE\\'.\" } }",
+      "grpc-status-details-bin" => "\b\x03\x12%Request contains an invalid argument.\x1A}\nCtype.googleapis.com/google.ads.googleads.#{version}.errors.GoogleAdsFailure\x126\n4\n\x02\b\x10\x12.Invalid customer ID 'INSERT_CUSTOMER_ID_HERE'.\x1A\xD9\x02\n(type.googleapis.com/google.rpc.DebugInfo\x12\xAC\x02\x12\xA9\x02[ORIGINAL ERROR] generic::invalid_argument: Invalid customer ID 'INSERT_CUSTOMER_ID_HERE'. [google.rpc.error_details_ext] { details { type_url: \"type.googleapis.com/google.ads.googleads.v1.errors.GoogleAdsFailure\" value: \"\\n4\\n\\002\\010\\020\\022.Invalid customer ID \\'INSERT_CUSTOMER_ID_HERE\\'.\" } }",
+      "request-id" =>"btwmoTYjaQE1UwVZnDCGAA",
+    }
+  end
+
+  def make_request(customer_id: "123123123")
+    Google::Ads::GoogleAds::V1::Services::MutateMediaFilesRequest.new(
+      customer_id: customer_id,
       operations: [
         Google::Ads::GoogleAds::V1::Services::MediaFileOperation.new(
           create: Google::Ads::GoogleAds::V1::Resources::MediaFile.new(

--- a/test/test_logging_interceptor.rb
+++ b/test/test_logging_interceptor.rb
@@ -19,7 +19,6 @@
 
 require 'minitest/autorun'
 
-require 'google/ads/google_ads'
 require 'google/ads/google_ads/logging_interceptor'
 require 'google/ads/google_ads/v1/services/media_file_service_services_pb'
 


### PR DESCRIPTION
Also fixes a bug where v1 errors were not printing debug info.