### PR TITLE
Add class for dealing with partial_failure_error

### DIFF
--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -206,6 +206,13 @@ module Google
           @logger = logger
         end
 
+        # Decode a partial failure error from a response.
+        # See Google::Ads::GoogleAds::PartialFailureErrorDecoder for full
+        # documentation.
+        def decode_partial_failure_error(pfe)
+          PartialFailureErrorDecoder.decode(pfe)
+        end
+
         private
 
         ERROR_TRANSFORMER = Proc.new do |gax_error|

--- a/lib/google/ads/google_ads/logging_interceptor.rb
+++ b/lib/google/ads/google_ads/logging_interceptor.rb
@@ -17,6 +17,7 @@
 # Interceptor to log outgoing requests and incoming responses.
 
 require 'google/ads/google_ads/api_versions'
+require 'google/ads/google_ads/partial_failure_error_decoder'
 require 'grpc/generic/interceptors'
 require 'json'
 
@@ -42,6 +43,9 @@ module Google
             @logger.info(build_summary_message(request, call, method, false))
             @logger.debug(build_request_message(metadata, request))
             @logger.debug(build_success_response_message(response))
+            if response.respond_to?(:partial_failure_error) && response.partial_failure_error
+              @logger.warn(build_partial_failure_message(response))
+            end
             response
           rescue Exception
             @logger.warn(build_summary_message(request, call, method, true))
@@ -52,6 +56,16 @@ module Google
         end
 
         private
+
+        def build_partial_failure_message(response)
+          errors = PartialFailureErrorDecoder.decode(
+            response.partial_failure_error
+          )
+          errors.reduce("Partial failure errors: ") do |accum, error|
+            accum += error.to_json + "\n"
+            accum
+          end
+        end
 
         def build_error_response_message
           # this looks like "magic", but the Google::Gax::GaxError grabs

--- a/lib/google/ads/google_ads/partial_failure_error_decoder.rb
+++ b/lib/google/ads/google_ads/partial_failure_error_decoder.rb
@@ -1,0 +1,24 @@
+module Google
+  module Ads
+    module GoogleAds
+      class PartialFailureErrorDecoder
+        # decodes a partial_failure_error (Google::Rpc::Status instance) to
+        # an array of meaningful error protos
+        #
+        # Return an Array of protobuf objects, typed depending on what was
+        # in the passed object (which will mostly be Google::Protobuf::Any,
+        # so the types could be any valid protobuf type)
+        def self.decode(partial_failure_error)
+          partial_failure_error.details.select { |detail|
+            Google::Protobuf::Any === detail
+          }.map { |detail|
+            type = Google::Protobuf::DescriptorPool.generated_pool.lookup(
+              detail.type_name
+            ).msgclass
+            detail.unpack(type)
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/test_google_ads_client.rb
+++ b/test/test_google_ads_client.rb
@@ -47,6 +47,31 @@ class TestGoogleAdsClient < Minitest::Test
     end
   end
 
+  def test_decode_partial_failure_error
+    response_with_pfe = Google::Ads::GoogleAds::V1::Services::MutateMediaFilesResponse.new(
+      results: [],
+      partial_failure_error: Google::Rpc::Status.new(
+        code: 13,
+        message: "Multiple errors in ‘details’. First error: A required field was not specified or is an empty string., at operations[0].create.type",
+        details: [
+          Google::Protobuf::Any.new(
+            type_url: "type.googleapis.com/google.ads.googleads.v1.errors.GoogleAdsFailure",
+            value: "\nh\n\x03\xB0\x05\x06\x129A required field was not specified or is an empty string.\x1A\x02*\x00\"\"\x12\x0E\n\noperations\x12\x00\x12\b\n\x06create\x12\x06\n\x04type\n=\n\x02P\x02\x12\x1FAn internal error has occurred.\x1A\x02*\x00\"\x12\x12\x10\n\noperations\x12\x02\b\x01".b
+          )
+        ]
+      )
+    )
+
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new() do |config|
+      # No setup.
+    end
+
+    errors = client.decode_partial_failure_error(
+      response_with_pfe.partial_failure_error,
+    )
+    assert_equal errors[0].class, Google::Ads::GoogleAds::V1::Errors::GoogleAdsFailure
+  end
+
   def test_config()
     refresh_token_value_1 = 'refresh token'
     client_id_value_1 = 'client id'


### PR DESCRIPTION
Also implements logging for the partial failure error messages at the
WARN level.

So for example if a user makes a request:

```ruby
response = media_file_service.mutate_media_files(
  customer_id,
  [
    media_file_logo_op,
    media_file_marketing_image_op,
  ],
  partial_failure: true,
  validate_only: true,
)
```

they can then say

```ruby
Google::Ads::GoogleAds::PartialFailureDecoder.decode(
  response.partial_failure_error
)
```

and they weill get back fully hydrated typed protos with full
information about what went wrong, in this case, see the attached new
test for the logging interceptor for exactly what comes out the other
side.

The reason that this doesn't use the `EXCEPTION_TRANSFORMER` is that we
don't get an exception raised when a partial failure occurs, and I
think we shouldn't, rather leaving it to the user to decide what to do.
Setting the partial failure flag indicates that they were happy for part
of the request to succeed, and that they then need to use the
convenience class to post-process and work out what they need to do next
time to make their request.

Fixes #50.