### PR TITLE
Changing the log level for partial failure errors to DEBUG

### DIFF
--- a/lib/google/ads/google_ads/logging_interceptor.rb
+++ b/lib/google/ads/google_ads/logging_interceptor.rb
@@ -44,7 +44,7 @@ module Google
             @logger.debug(build_request_message(metadata, request))
             @logger.debug(build_success_response_message(response))
             if response.respond_to?(:partial_failure_error) && response.partial_failure_error
-              @logger.warn(build_partial_failure_message(response))
+              @logger.debug(build_partial_failure_message(response))
             end
             response
           rescue Exception


### PR DESCRIPTION
A user who gets a partial failure response must have specifically requested it, and this log level matches the other extended information fields for otherwise successful requests.