### PR TITLE
Add `ExtensionFeedItem` as an operation look up

### DIFF
--- a/lib/google/ads/google_ads/utils/v1/proto_lookup_util.rb
+++ b/lib/google/ads/google_ads/utils/v1/proto_lookup_util.rb
@@ -678,6 +678,7 @@ module Google
               Customer: ['customer_service_pb', 'CustomerOperation'],
               ConversionAction: ['conversion_action_service_pb', 'ConversionActionOperation'],
               DismissRecommendation: ['recommendation_service_pb', 'DismissRecommendationRequest::DismissRecommendationOperation'],
+              ExtensionFeedItem: ['extension_feed_item_service_pb', 'ExtensionFeedItemOperation'],
               ExtensionFeedItemOperation: ['extension_feed_item_service_pb', 'ExtensionFeedItemOperation'],
               FeedItem: ['feed_item_service_pb', 'FeedItemOperation'],
               FeedItemTarget: ['feed_item_target_service_pb', 'FeedItemTargetOperation'],


### PR DESCRIPTION
This was created originally as `ExtensionFeedItemOperation`, but that
doesn't quite match the uniform pattern that we use, so this adds the
extra value, so that we don't break anyone who's already using it, but
the consistent value is available.