### PR TITLE
Validate all protos are loadable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,15 @@ def apply_patches
   end
 end
 
+task :validate_protos do
+  res = system("./scripts/validate_protos.rb")
+  if !res
+    raise "Couldn't load all protos"
+  end
+end
+
 task :apply_patches do |t|
   apply_patches
 end
 
-task :build => :apply_patches
+task :build => [:apply_patches, :validate_protos]

--- a/scripts/validate_protos.rb
+++ b/scripts/validate_protos.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+$: << "./lib/"
+
+require 'google/ads/google_ads'
+["resources", "enums", "services", "common", "errors"].each do |dir|
+  Dir["./lib/google/ads/google_ads/v1/#{dir}/**/*.rb"].each do |fn|
+    require fn.gsub("./lib/", "").gsub(".rb", "")
+  end
+end


### PR DESCRIPTION
Building on top of #80 this adds a script which loads every proto file and causes rake to terminate *after* patching all the proto files.

This way, we get validation that all the protos in the library are actually well formed and loadable.