### PR TITLE
Revert "Make autoboxing fields work with constructors (#126)"

### DIFF
--- a/lib/google/ads/google_ads/autoboxing_fields.rb
+++ b/lib/google/ads/google_ads/autoboxing_fields.rb
@@ -27,38 +27,16 @@ module Google
           klass.instance_variable_set(:@_patched_for_autoboxing_fields, true)
 
           klass.instance_eval do
-            fields = []
             descriptor.each do |field|
               if field.type == :message && AutoboxingFields.is_value_field?(field.subtype.msgclass)
-                fields << field
                 AutoboxingFields.patch_field_for_autoboxing(field, self)
               end
             end
-
-            AutoboxingFields.patch_constructor_for_autoboxing(fields, self)
           end
         end
 
         def self.is_value_field?(class_name)
           MAPPINGS.keys.include?(class_name)
-        end
-
-        def self.patch_constructor_for_autoboxing(fields, klass_to_patch)
-          orig_initialize = klass_to_patch.instance_method(:initialize)
-          klass_to_patch.instance_eval do
-            define_method(:initialize) do |**kwargs|
-              new_kwargs = Hash[kwargs.map { |name, value|
-                field = fields.select { |x| x.name == name.to_s }.first
-                actual_value = if field
-                                 field.subtype.msgclass.new(value: MAPPINGS.fetch(field.subtype.msgclass).call(value))
-                               else
-                                 value
-                               end
-                [name, actual_value]
-              }]
-              orig_initialize.bind(self).call(**new_kwargs)
-            end
-          end
         end
 
         def self.patch_field_for_autoboxing(field, klass_to_patch)

--- a/test/test_autoboxing_fields.rb
+++ b/test/test_autoboxing_fields.rb
@@ -22,10 +22,6 @@ require 'google/ads/google_ads/v1/resources/campaign_pb'
 
 class TestAutoboxing < Minitest::Test
   def test_initialize
-    Google::Ads::GoogleAds::V1::Resources::Campaign.new(name: "hi")
-  end
-
-  def test_assign
     c = Google::Ads::GoogleAds::V1::Resources::Campaign.new
     c.name = "hi"
     c.id = 3


### PR DESCRIPTION
This reverts commit 15a1108c2f22c5a059251692bfa76ec58eecdc37.