### PR TITLE
Extract service creation

### DIFF
--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -52,7 +52,7 @@ require 'google/ads/google_ads/wrapper_util'
 require 'google/ads/google_ads/logging_interceptor'
 require 'google/ads/google_ads/factories'
 require 'google/ads/google_ads/errors'
-require 'google/ads/google_ads/lookup_service'
+require 'google/ads/google_ads/service_lookup'
 
 require 'google/gax'
 
@@ -116,7 +116,7 @@ module Google
         def service(name=nil, version = default_api_version)
           service_path = ENV['GOOGLEADS_SERVICE_PATH']
 
-          LookupService.new(
+          ServiceLookup.new(
             name,
             version,
             lookup_util,

--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -52,7 +52,7 @@ require 'google/ads/google_ads/wrapper_util'
 require 'google/ads/google_ads/logging_interceptor'
 require 'google/ads/google_ads/factories'
 require 'google/ads/google_ads/errors'
-require 'google/ads/google_ads/patch_lro_headers'
+require 'google/ads/google_ads/lookup_service'
 
 require 'google/gax'
 
@@ -116,80 +116,16 @@ module Google
         def service(name=nil, version = default_api_version)
           service_path = ENV['GOOGLEADS_SERVICE_PATH']
 
-          # We need a local reference to refer to from within the class block
-          # below.
-          logger = @logger
 
-          headers = {
-            :"developer-token" => @config.developer_token
-          }
-          if @config.login_customer_id
-            begin
-              login_customer_id = Integer(@config.login_customer_id)
-            rescue ArgumentError => e
-              if e.message.start_with?("invalid value for Integer")
-                raise ArgumentError.new("Invalid value for login_customer_id, must be integer")
-              end
-            end
-            if login_customer_id <= 0 || login_customer_id > 9_999_999_999
-              raise ArgumentError.new(
-                "Invalid login_customer_id. Must be an integer " \
-                "0 < x <= 9,999,999,999. Got #{login_customer_id}"
-              )
-            end
-            headers[:"login-customer-id"] = login_customer_id.to_s  # header values must be strings
-          end
-
-          if logger
-            logging_interceptor = Google::Ads::GoogleAds::LoggingInterceptor.new(logger)
-          end
-
-          if name.nil?
-            services = Factories.at_version(version).services.new(
-              service_path: service_path,
-              logging_interceptor: logging_interceptor,
-              credentials: get_updater_proc,
-              metadata: headers,
-              exception_transformer: ERROR_TRANSFORMER
-            )
-
-            patch_delegator = Class.new do
-              def initialize(services, headers, patch_callable)
-                @services = services
-                @headers = headers
-                @patch_callable = patch_callable
-              end
-
-              def respond_to_missing?(sym, include_private=false)
-                @services.respond_to?(sym, include_private)
-              end
-
-              def method_missing(name, *args)
-                @services.public_send(name, *args) do |cls|
-                  @patch_callable.call(cls, @headers)
-                  cls
-                end
-              end
-            end
-            patch_delegator.new(services, headers, method(:patch_lro_headers))
-          else
-            class_to_return = lookup_util.raw_service(name, version)
-            class_to_return = Class.new(class_to_return) do
-              unless service_path.nil? || service_path.empty?
-                const_set('SERVICE_ADDRESS', service_path.freeze)
-              end
-
-              const_set('GRPC_INTERCEPTORS', [logging_interceptor].compact)
-            end
-
-            patch_lro_headers(class_to_return, headers)
-
-            class_to_return.new(
-              credentials: get_updater_proc,
-              metadata: headers,
-              exception_transformer: ERROR_TRANSFORMER
-            )
-          end
+          LookupService.new(
+            name,
+ version,
+ lookup_util,
+ service_path,
+ @logger,
+ @config,
+ get_updater_proc
+                           ).call
         end
 
         def patch_lro_headers(class_to_return, headers)

--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -116,16 +116,15 @@ module Google
         def service(name=nil, version = default_api_version)
           service_path = ENV['GOOGLEADS_SERVICE_PATH']
 
-
           LookupService.new(
             name,
- version,
- lookup_util,
- service_path,
- @logger,
- @config,
- get_updater_proc
-                           ).call
+            version,
+            lookup_util,
+            service_path,
+            @logger,
+            @config,
+            get_updater_proc
+          ).call
         end
 
         def patch_lro_headers(class_to_return, headers)

--- a/lib/google/ads/google_ads/lookup_service.rb
+++ b/lib/google/ads/google_ads/lookup_service.rb
@@ -23,21 +23,9 @@ module Google
           headers = {
             :"developer-token" => @config.developer_token
           }
-          if @config.login_customer_id
-            begin
-              login_customer_id = Integer(@config.login_customer_id)
-            rescue ArgumentError => e
-              if e.message.start_with?("invalid value for Integer")
-                raise ArgumentError.new("Invalid value for login_customer_id, must be integer")
-              end
-            end
-            if login_customer_id <= 0 || login_customer_id > 9_999_999_999
-              raise ArgumentError.new(
-                "Invalid login_customer_id. Must be an integer " \
-                "0 < x <= 9,999,999,999. Got #{login_customer_id}"
-              )
-            end
-            headers[:"login-customer-id"] = login_customer_id.to_s  # header values must be strings
+          if config.login_customer_id
+            validate_login_customer_id
+            headers[:"login-customer-id"] = config.login_customer_id.to_s  # header values must be strings
           end
 
           if logger
@@ -98,6 +86,22 @@ module Google
           PatchLROHeaders.new(class_to_return, headers).call
         end
 
+        def validate_login_customer_id
+          begin
+            login_customer_id = Integer(config.login_customer_id)
+          rescue ArgumentError => e
+            if e.message.start_with?("invalid value for Integer")
+              raise ArgumentError.new("Invalid value for login_customer_id, must be integer")
+            end
+          end
+          if login_customer_id <= 0 || login_customer_id > 9_999_999_999
+            raise ArgumentError.new(
+              "Invalid login_customer_id. Must be an integer " \
+              "0 < x <= 9,999,999,999. Got #{login_customer_id}"
+            )
+          end
+        end
+
         ERROR_TRANSFORMER = Proc.new do |gax_error|
           begin
             gax_error.status_details.each do |detail|
@@ -126,7 +130,6 @@ module Google
           # error while processing, just throw the original.
           raise gax_error
         end
-
 
         attr_reader :name
         attr_reader :version

--- a/lib/google/ads/google_ads/service_lookup.rb
+++ b/lib/google/ads/google_ads/service_lookup.rb
@@ -3,15 +3,15 @@ require 'google/ads/google_ads/patch_lro_headers'
 module Google
   module Ads
     module GoogleAds
-      class LookupService
+      class ServiceLookup
         def initialize(name, version, lookup_util, service_path, logger, config, updater_proc)
           @name = name
           @version = version
+          @lookup_util = lookup_util
           @service_path = service_path
           @logger = logger
           @config = config
           @updater_proc = updater_proc
-          @lookup_util = lookup_util
         end
 
         def call


### PR DESCRIPTION
This is a preparatory refactoring for allowing us to pass our own channels in to the code gax creates. We're doing this so that we can set the maximum message size on the channel to 64mb. To do this we need to pass a `GRPC::Core::Channel` in the position that `credentials` currently occupies. The problem that we have right now is that we've got two different ways of creating services. Until we've done some open source stuff, we can't merge that PR.

SO

this PR applies the "method object" refactoring to pull the (ever expanding) `Google::Ads::GoogleAdsClient#service` method out in to it's own object in the first commit, and then just applies the extract method refactoring over and over again. This basically is just to reduce the cognitive overhead of swapping in a grpc channel instead of an updater proc.