### PR TITLE
Adds very simple support for a HTTP proxy.

### DIFF
--- a/google_ads_config.rb
+++ b/google_ads_config.rb
@@ -78,4 +78,7 @@ Google::Ads::GoogleAds::Config.new do |c|
   # logger directly (e.g. passing Rails.logger in a config/initializer). The
   # passed logger will override log_level and log_target.
   # c.logger = Logger.new(STDOUT)
+
+  # If you need to use a HTTP proxy you can set one with this config attribute
+  # c.http_proxy = "http://example.com:8080"
 end

--- a/lib/google/ads/google_ads/config.rb
+++ b/lib/google/ads/google_ads/config.rb
@@ -16,6 +16,8 @@
 #
 # Configuration setup for and storage for the API.
 
+require 'uri'
+
 module Google
   module Ads
     module GoogleAds
@@ -61,6 +63,19 @@ module Google
 
         def configure(&block)
           yield self
+        end
+
+        def http_proxy=(uri)
+          u = URI.parse(uri)
+          if u.scheme != "http" && u.scheme != "https"
+            raise ArgumentError, "#{uri} has invalid scheme #{u.scheme}, should be http or https"
+          end
+
+          ENV["http_proxy"] = uri
+        end
+
+        def http_proxy
+          ENV["http_proxy"]
         end
       end
     end


### PR DESCRIPTION
This works by setting the environment variable that [GRPC uses](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/http_proxy.cc)
when the user specifies it on their configuration file.