### PR TITLE
Fix codegen dependencies.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ def factories_are_recent?
   newest_factory_file > newest_proto_file
 end
 
-task :codegen do |t|
+task :codegen => [:apply_patches, :copy_third_party_code] do |t|
   `./scripts/codegen.sh` unless factories_are_recent?
 end
 
@@ -70,5 +70,5 @@ task :copy_third_party_code do |t|
   `cp third_party/rspec/caller_filter.rb lib/google/ads/google_ads/deprecation.rb`
 end
 
-task :build => [:apply_patches, :copy_third_party_code, :codegen, :validate_protos]
+task :build => [:codegen, :validate_protos]
 task :test => [:copy_third_party_code, :codegen]


### PR DESCRIPTION
Previously I was running `bundle exec rake build` to make the gem usable
from scratch. However, this is not actually ideal for dev/testing.
Codegen needs patch and third party code, so this better expresses the
real dependencies that we have so that we can build for dev without
having to actually compile a gem.