### PR TITLE
Fixing AdGroupAd status to be ENABLED

### DIFF
--- a/examples/hotel_ads/add_hotel_ad.rb
+++ b/examples/hotel_ads/add_hotel_ad.rb
@@ -153,7 +153,7 @@ def add_hotel_ad_group_ad(client, customer_id, ad_group_resource)
     aga.ad = client.resource.ad do |ad|
       ad.hotel_ad = client.resource.hotel_ad_info
     end
-    aga.status = :PAUSED
+    aga.status = :ENABLED
 
     # Set the ad group.
     aga.ad_group = ad_group_resource


### PR DESCRIPTION
There was a change for Hotels that causes an error when setting `AdGroupAd` to `PAUSED` and should always be `ENABLED`.  Setting `AdGroupAd`'s status to `PAUSED` will now throw a `OPERATION_NOT_PERMITTED_FOR_CAMPAIGN_TYPE`, this is expected as the status for `AdGroupAd` for Hotel campaigns should always be `ENABLED`.