### PR TITLE
Adding comment for ad group ad status

### DIFF
--- a/examples/hotel_ads/add_hotel_ad.rb
+++ b/examples/hotel_ads/add_hotel_ad.rb
@@ -153,6 +153,9 @@ def add_hotel_ad_group_ad(client, customer_id, ad_group_resource)
     aga.ad = client.resource.ad do |ad|
       ad.hotel_ad = client.resource.hotel_ad_info
     end
+    # Set the ad group ad to enabled.  Setting this to paused will cause an error
+    # for hotel campaigns.  For hotels pausing should happen at either the ad group or
+    # campaign level.
     aga.status = :ENABLED
 
     # Set the ad group.


### PR DESCRIPTION
- Adding comment about why ad group ad should be enabled for hotels, originally brought up in https://github.com/googleads/google-ads-dotnet/pull/123#discussion_r352711245