### PR TITLE
fix block syntax for operations (issue #225 and #227)

### DIFF
--- a/codegen/templates/operations.rb.erb
+++ b/codegen/templates/operations.rb.erb
@@ -10,7 +10,13 @@ module Google
             # @return [<%= operation.operation.name %>] the operation
             def self.<%= operation.operation.name.split("::").last.underscore.gsub("_operation", "") %>
               require "<%= operation.path %>"
-              <%= operation.operation.name %>.new
+              if block_given?
+                op = <%= operation.operation.name %>.new
+                yield op
+                op
+              else
+                <%= operation.operation.name %>.new
+              end
             end
             <% end %>
 
@@ -60,6 +66,8 @@ module Google
                   op["create"] = res
                 elsif !blk.nil?
                   op["create"] = Factories::<%= version.to_s.camelize %>::Resources.<%= operation.create_class.name.split("::").last.underscore %>(&blk)
+                else
+                  op["create"] = Factories::<%= version.to_s.camelize %>::Resources.<%= operation.create_class.name.split("::").last.underscore %>
                 end
 
                 op
@@ -110,7 +118,7 @@ module Google
 
             module RemoveResource
               <% operations.each do |operation| %>
-              # A convenience method for creationg an <%= operation.operation.name.split("::").last %> instance with
+              # A convenience method for creating an <%= operation.operation.name.split("::").last %> instance with
               # its "remove" field preopulated with a resource path corresponding to the resource to be removed.
               #
               # @param path [String] the resource name of the resource to delete.

--- a/examples/campaign_management/add_complete_campaigns_using_batch_job.rb
+++ b/examples/campaign_management/add_complete_campaigns_using_batch_job.rb
@@ -55,9 +55,7 @@ end
 # [START add_complete_campaigns_using_batch_job]
 def create_batch_job(client, batch_job_service, customer_id)
   # Creates a batch job operation to create a new batch job.
-  operation = client.operation.create_resource.batch_job do |job|
-    # Empty block to make sure the operation is created correctly.
-  end
+  operation = client.operation.create_resource.batch_job
 
   # Issues a request to the API and get the batch job's resource name.
   response = batch_job_service.mutate_batch_job(
@@ -143,18 +141,18 @@ def build_all_operations(client, customer_id)
   # Creates a new campaign budget operation and add it to the array of mutate
   # operations.
   campaign_budget_operation = build_campaign_budget_operation(client, customer_id)
-  mutate_op = client.operation.mutate
-  mutate_op.campaign_budget_operation = campaign_budget_operation
-  mutate_operations << mutate_op
+  mutate_operations << client.operation.mutate do |mutate_op|
+    mutate_op.campaign_budget_operation = campaign_budget_operation
+  end
 
   # Creates new campaign operations and adds them to the array of mutate
   # operations.
   campaign_operations = build_campaign_operations(
     client, customer_id, campaign_budget_operation.create.resource_name)
   campaign_operations.each do |op|
-    mutate_op = client.operation.mutate
-    mutate_op.campaign_operation = op
-    mutate_operations << mutate_op
+    mutate_operations << client.operation.mutate do |mutate_op|
+      mutate_op.campaign_operation = op
+    end
   end
 
   # Creates new campaign criterion operations and adds them to the array of
@@ -162,9 +160,9 @@ def build_all_operations(client, customer_id)
   campaign_criterion_operations = build_campaign_criterion_operations(
     client, campaign_operations)
   campaign_criterion_operations.each do |op|
-    mutate_op = client.operation.mutate
-    mutate_op.campaign_criterion_operation = op
-    mutate_operations << mutate_op
+    mutate_operations << client.operation.mutate do |mutate_op|
+      mutate_op.campaign_criterion_operation = op
+    end
   end
 
   # Creates new ad group operations and adds them to the array of mutate
@@ -172,9 +170,9 @@ def build_all_operations(client, customer_id)
   ad_group_operations = build_ad_group_operations(
     client, customer_id, campaign_operations)
   ad_group_operations.each do |op|
-    mutate_op = client.operation.mutate
-    mutate_op.ad_group_operation = op
-    mutate_operations << mutate_op
+    mutate_operations << client.operation.mutate do |mutate_op|
+      mutate_op.ad_group_operation = op
+    end
   end
 
   # Creates new ad group criterion operations and adds them to the array of
@@ -182,9 +180,9 @@ def build_all_operations(client, customer_id)
   ad_group_criterion_operations = build_ad_group_criterion_operations(
     client, ad_group_operations)
   ad_group_criterion_operations.each do |op|
-    mutate_op = client.operation.mutate
-    mutate_op.ad_group_criterion_operation = op
-    mutate_operations << mutate_op
+    mutate_operations << client.operation.mutate do |mutate_op|
+      mutate_op.ad_group_criterion_operation = op
+    end
   end
 
   # Creates new ad group ad operations and adds them to the array of mutate
@@ -192,9 +190,9 @@ def build_all_operations(client, customer_id)
   ad_group_ad_operations = build_ad_group_ad_operations(
     client, ad_group_operations)
   ad_group_ad_operations.each do |op|
-    mutate_op = client.operation.mutate
-    mutate_op.ad_group_ad_operation = op
-    mutate_operations << mutate_op
+    mutate_operations << client.operation.mutate do |mutate_op|
+      mutate_op.ad_group_ad_operation = op
+    end
   end
 
   mutate_operations

--- a/test/test_object_creation.rb
+++ b/test/test_object_creation.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+# Encoding: utf-8
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests object creation.
+
+require 'minitest/autorun'
+
+require 'google/ads/google_ads/google_ads_client'
+
+class TestResourceCreation < Minitest::Test
+  def test_resource_creation_default()
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new
+    campaign_op = client.operation.v6.create_resource.campaign
+    assert_instance_of(Google::Ads::GoogleAds::V6::Resources::Campaign, campaign_op.create)
+  end
+
+  def test_resource_creation_from_existing_object()
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new
+    campaign = client.resource.campaign do |c|
+      c.name = "test campaign"
+      c.id = 123456
+    end
+    campaign_op = client.operation.create_resource.campaign(campaign)
+    assert_equal(campaign_op.create.name, "test campaign")
+    assert_equal(campaign_op.create.id, 123456)
+  end
+
+  def test_resource_creation_using_block()
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new
+    campaign_op = client.operation.create_resource.campaign do |c|
+      c.name = "test campaign"
+      c.id = 123456
+    end
+    assert_equal(campaign_op.create.name, "test campaign")
+    assert_equal(campaign_op.create.id, 123456)
+  end
+
+  def test_operation_creation_default()
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new
+    mutate_op = client.operation.v6.mutate
+    assert_instance_of(Google::Ads::GoogleAds::V6::Services::MutateOperation, mutate_op)
+  end
+
+  def test_operation_creation_using_block()
+    client = Google::Ads::GoogleAds::GoogleAdsClient.new
+    mutate_op = client.operation.v6.mutate do |op|
+      op.campaign_operation = client.operation.v6.create_resource.campaign
+    end
+    assert_instance_of(Google::Ads::GoogleAds::V6::Services::MutateOperation, mutate_op)
+    assert_instance_of(Google::Ads::GoogleAds::V6::Services::CampaignOperation, mutate_op.campaign_operation)
+  end
+end


### PR DESCRIPTION
- support block syntax for client.operation.operation_name
- support direct creation without block for client.operation.create_resource.resource_type

resolves #225, resolves #227 