### PR TITLE
Switch example CLI arguments to boolean (#265)

### DIFF
--- a/examples/shopping_ads/add_shopping_product_ad.rb
+++ b/examples/shopping_ads/add_shopping_product_ad.rb
@@ -215,8 +215,8 @@ if __FILE__ == $0
     end
 
     opts.on('-d', '--create-default-listing-group CREATE-DEFAULT-LISTING-GROUP',
-        String, 'Create Default Listing Group') do |v|
-      options[:create_default_listing_group] = true if v
+        TrueClass, 'Create Default Listing Group') do |v|
+      options[:create_default_listing_group] = v
     end
 
     opts.separator ''

--- a/examples/shopping_ads/add_shopping_product_listing_group_tree.rb
+++ b/examples/shopping_ads/add_shopping_product_listing_group_tree.rb
@@ -326,8 +326,8 @@ if __FILE__ == $0
     end
 
     opts.on('-r', '--replace-existing-tree REPLACE-EXISTING-TREE',
-            String, 'Create Default Listing Group') do |v|
-      options[:should_replace_existing_tree] = true if v
+        TrueClass, 'Create Default Listing Group') do |v|
+      options[:should_replace_existing_tree] = v
     end
 
     opts.separator ''

--- a/examples/shopping_ads/add_shopping_smart_ad.rb
+++ b/examples/shopping_ads/add_shopping_smart_ad.rb
@@ -241,8 +241,8 @@ if __FILE__ == $0
     end
 
     opts.on('-d', '--create-default-listing-group CREATE-DEFAULT-LISTING-GROUP',
-        String, 'Create Default Listing Group') do |v|
-      options[:create_default_listing_group] = true if v
+        TrueClass, 'Create Default Listing Group') do |v|
+      options[:create_default_listing_group] = v
     end
 
     opts.separator ''


### PR DESCRIPTION
Closes #265 

```console
ruby examples/shopping_ads/add_shopping_product_ad.rb --create-default-listing-group true
ruby examples/shopping_ads/add_shopping_product_ad.rb --create-default-listing-group false

ruby examples/shopping_ads/add_shopping_product_listing_group_tree.rb --replace-existing-tree true
ruby examples/shopping_ads/add_shopping_product_listing_group_tree.rb --replace-existing-tree false

ruby examples/shopping_ads/add_shopping_smart_ad.rb  --create-default-listing-group true
ruby examples/shopping_ads/add_shopping_smart_ad.rb  --create-default-listing-group  false