### PR TITLE
Update upload_conversion_enhancement.rb

### DIFF
--- a/examples/remarketing/upload_conversion_enhancement.rb
+++ b/examples/remarketing/upload_conversion_enhancement.rb
@@ -131,7 +131,7 @@ def normalize_and_hash_email(email)
   email_parts = email.downcase.split("@")
   # Removes any '.' characters from the portion of the email address before the
   # domain if the domain is gmail.com or googlemail.com.
-  if email_parts.last === /^(gmail|googlemail)\\.com\\s*/
+  if email_parts.last =~ /^(gmail|googlemail)\.com\s*/
     email_parts[0] = email_parts[0].gsub('.', '')
   end
   normalize_and_hash(email_parts.join('@'))


### PR DESCRIPTION
fix regex comparison of ruby's example

`'gmail.com' =~ /^(gmail|googlemail)\.com\s*/` // 0
`'googlemail.com' =~ /^(gmail|googlemail)\.com\s*/` // 0
`'googlemail' =~ /^(gmail|googlemail)\.com\s*/` // nil
