### PR TITLE
Update upload_conversion_with_identifiers.rb

### DIFF
--- a/examples/remarketing/upload_conversion_with_identifiers.rb
+++ b/examples/remarketing/upload_conversion_with_identifiers.rb
@@ -88,7 +88,7 @@ def normalize_and_hash_email(email)
   email_parts = email.downcase.split("@")
   # Removes any '.' characters from the portion of the email address before the
   # domain if the domain is gmail.com or googlemail.com.
-  if email_parts.last === /^(gmail|googlemail)\\.com\\s*/
+  if email_parts.last =~ /^(gmail|googlemail)\.com\s*/
     email_parts[0] = email_parts[0].gsub('.', '')
   end
   normalize_and_hash(email_parts.join('@'))


### PR DESCRIPTION
https://github.com/googleads/google-ads-ruby/pull/435 missed an instance of the same problem

> fix regex comparison of ruby's example
> 
> new
> 'gmail.com' =~ /^(gmail|googlemail)\.com\s*/ // 0
> 'googlemail.com' =~ /^(gmail|googlemail)\.com\s*/ // 0
> 'googlemail' =~ /^(gmail|googlemail)\.com\s*/ // nil
> 
> old, always false
> 'gmail.com' === /^(gmail|googlemail)\\.com\\s*/ // false
> 'googlemail.com' === /^(gmail|googlemail)\\.com\\s*/ // false
> 'googlemail' === /^(gmail|googlemail)\\.com\\s*/ // false