### PR TITLE
Only use resource_name when customer_id isn't already set

### DIFF
--- a/lib/google/ads/google_ads/interceptors/logging_interceptor.rb
+++ b/lib/google/ads/google_ads/interceptors/logging_interceptor.rb
@@ -299,11 +299,13 @@ module Google
           end
 
           def build_summary_message(request, call, method, is_fault)
-            customer_id = "N/A"
-            customer_id = request.customer_id if request.respond_to?(:customer_id)
-            # CustomerService get requests have a different format.
-            if request.respond_to?(:resource_name)
-              customer_id = request.resource_name.split('/').last
+            customer_id = if request.respond_to?(:customer_id)
+              request.customer_id
+            elsif request.respond_to?(:resource_name)
+              segments = request.resource_name.split('/')
+              segments[1] if segments[0] == "customers"
+            else
+              "N/A"
             end
 
             is_fault_string = if is_fault


### PR DESCRIPTION
This PR fixes (I think) a bug where the Customer ID is being overridden incorrectly by the resource ID in the logs.

The current bug with this behaviour is the Customer ID is being logged incorrectly for some requests such as checking offline user jobs which have the resource name in this format:

```
/customers/{customer_id}/offlineUserDataJobs/{job_id}
```

Right now, the `customer_id` will be set to `job_id`, which is wrong. 

I think the logic is meant to be, "only use the resource name if the customer ID is _not_ set", rather than defaulting to using the resource name to derive the Customer ID all the time.

This PR attempts to make that change.

