### PR TITLE
Pin deprecated APIs to V14

### DIFF
--- a/examples/account_management/approve_merchant_center_link.rb
+++ b/examples/account_management/approve_merchant_center_link.rb
@@ -18,15 +18,20 @@
 # This code example accepts all pending invitations from Google Merchant Center
 # accounts to your Google Ads account.
 
+# NOTE: This code example uses version v14 of the Google Ads API.
+# Version v15 of the Google Ads API replaces MerchantCenterLinkService with
+# ProductLinkInvitationService and ProductLinkService. We will add new code
+# examples using these services shortly.
+
 require 'optparse'
 require 'google/ads/google_ads'
 
 def approve_merchant_center_links(customer_id, merchant_center_account_id)
-  client = Google::Ads::GoogleAds::GoogleAdsClient.new
+  client = Google::Ads::GoogleAds::GoogleAdsClient::new
 
   # [START approve_merchant_center_link]
   # Retrieve all the existing Merchant Center links.
-  response = client.service.merchant_center_link.list_merchant_center_links(
+  response = client.service.v14.merchant_center_link.list_merchant_center_links(
     customer_id: customer_id,
   )
   # [END approve_merchant_center_link]
@@ -37,13 +42,13 @@ def approve_merchant_center_links(customer_id, merchant_center_account_id)
     # Enables the pending link.
     if link.status == :PENDING && link.id.to_s == merchant_center_account_id
       # Creates the update operation.
-      update_operation = client.operation.update_resource.merchant_center_link(
+      update_operation = client.operation.v14.update_resource.merchant_center_link(
         link.resource_name) do |updated_link|
         updated_link.status = :ENABLED
       end
 
       # Updates the link.
-      mutate_response = client.service.merchant_center_link.mutate_merchant_center_link(
+      mutate_response = client.service.v14.merchant_center_link.mutate_merchant_center_link(
         customer_id: customer_id,
         operation: update_operation,
       )

--- a/examples/account_management/reject_merchant_center_link.rb
+++ b/examples/account_management/reject_merchant_center_link.rb
@@ -25,13 +25,18 @@
 # for Shopping to send a link request between your Merchant Center and
 # Google Ads accounts.
 
+# NOTE: This code example uses version v14 of the Google Ads API.
+# Version v15 of the Google Ads API replaces MerchantCenterLinkService with
+# ProductLinkInvitationService and ProductLinkService. We will add new code
+# examples using these services shortly.
+
 require 'optparse'
 require 'google/ads/google_ads'
 
 def reject_merchant_center_links(customer_id, merchant_center_account_id)
   client = Google::Ads::GoogleAds::GoogleAdsClient.new
 
-  merchant_center_link_service = client.service.merchant_center_link
+  merchant_center_link_service = client.service.v14.merchant_center_link
 
   # Rejects a pending link request or unlinks an enabled link for a Google Ads
   # account with customer_id from a Merchant Center account with
@@ -76,7 +81,7 @@ def remove_merchant_center_link(
   link)
   # Creates a single remove operation, specifying the Merchant Center link
   # resource name.
-  operation = client.operation.remove_resource.merchant_center_link(link.resource_name)
+  operation = client.operation.v14.remove_resource.merchant_center_link(link.resource_name)
 
   # Issues a mutate request to remove the link and prints the result info.
   response = merchant_center_link_service.mutate_merchant_center_link(

--- a/examples/misc/upload_image.rb
+++ b/examples/misc/upload_image.rb
@@ -17,25 +17,34 @@
 #
 # This example uploads an image
 
+# NOTE: This code example uses version v14 of the Google Ads API.
+# Google Ads is migrating from individual media files to assets,
+# and version v15 of the API removed support for
+# MediaFileService as part of this migration. Once your Ads account is migrated, this code
+# example will stop working, and you should use upload_image_asset.rb instead. This code
+# example will be removed once the migration completes.
+# See https://ads-developers.googleblog.com/2023/07/image-and-location-auto-migration.html
+# for more details.
+
 require 'optparse'
 require 'google/ads/google_ads'
 require 'open-uri'
 
 def upload_image(customer_id)
-  image_data = open("https://gaagl.page.link/Eit5") { |f| f.read }
+  image_data = URI.open("https://gaagl.page.link/Eit5") { |f| f.read }
 
   # GoogleAdsClient will read a config file from
   # ENV['HOME']/google_ads_config.rb when called without parameters
   client = Google::Ads::GoogleAds::GoogleAdsClient.new
 
-  operation = client.operation.create_resource.media_file do |media_file|
+  operation = client.operation.v14.create_resource.media_file do |media_file|
     media_file.type = :IMAGE
-    media_file.image = client.resource.media_image do |media_image|
+    media_file.image = client.resource.v14.media_image do |media_image|
       media_image.data = image_data
     end
   end
 
-  media_file_service = client.service.media_file
+  media_file_service = client.service.v14.media_file
   response = media_file_service.mutate_media_files(
     customer_id: customer_id,
     operations: [operation],

--- a/examples/misc/upload_media_bundle.rb
+++ b/examples/misc/upload_media_bundle.rb
@@ -17,6 +17,13 @@
 #
 # This example uploads an HTML5 zip file as a media bundle.
 
+# NOTE: This code example uses version v14 of the Google Ads API.
+# Google Ads is migrating from individual media files to assets,
+# and version v15 of the API removed support for
+# MediaFileService as part of this migration.
+# See https://ads-developers.googleblog.com/2023/07/image-and-location-auto-migration.html
+# for more details.
+
 require 'optparse'
 require 'google/ads/google_ads'
 require 'open-uri'
@@ -27,19 +34,19 @@ def upload_media_bundle(customer_id)
   client = Google::Ads::GoogleAds::GoogleAdsClient.new
 
   url = 'https://gaagl.page.link/ib87'
-  bundle_content = open(url) { |f| f.read }
+  bundle_content = URI.open(url) { |f| f.read }
 
   # Creates a media file containing the bundle content.
-  operation = client.operation.create_resource.media_file do |media|
+  operation = client.operation.v14.create_resource.media_file do |media|
     media.name = 'Ad Media Bundle'
     media.type = :MEDIA_BUNDLE
-    media.media_bundle = client.resource.media_bundle do |bundle|
+    media.media_bundle = client.resource.v14.media_bundle do |bundle|
       bundle.data = bundle_content
     end
   end
 
   # Issues a mutate request to add the media file.
-  response = client.service.media_file.mutate_media_files(
+  response = client.service.v14.media_file.mutate_media_files(
     customer_id: customer_id,
     operations: [operation],
   )


### PR DESCRIPTION
Pins/Downgrades these examples to V14 since services have been removed in V15:

- accountmanagement/ApproveMerchantCenterLink
- accountmanagement/RejectMerchantCenterLink
- misc/UploadImage
- misc/UploadMediaBundle