### PR TITLE
Remove the usage of eCPC bidding because of its deprecation

### DIFF
--- a/examples/shopping_ads/add_shopping_product_ad.rb
+++ b/examples/shopping_ads/add_shopping_product_ad.rb
@@ -96,8 +96,13 @@ def add_standard_shopping_campaign(
 
     campaign.status = :PAUSED
 
+    # Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for standard
+    # Shopping campaigns is deprecated. If eCPC is set to true, Google Ads ignores the
+    # setting and behaves as if the setting was false. See this blog post for more
+    # information:
+    # https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
     campaign.manual_cpc = client.resource.manual_cpc do |manual_cpc|
-      manual_cpc.enhanced_cpc_enabled = true
+      manual_cpc.enhanced_cpc_enabled = false
     end
 
     campaign.campaign_budget = budget_name


### PR DESCRIPTION
To align with the [code example change](https://github.com/googleads/google-ads-java/pull/742) requested for the Java client library.

As seen in this [blog announcement](https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html), any Shopping campaigns using Enhanced cost-per-click (eCPC) will behave as if they are using Manual cost-per-click (CPC) bidding.

Because of the change, I'm updating the examples related to the announcement to reflect the new recommended practice.