### PR TITLE
Support direct access with Service Account

### DIFF
--- a/lib/google/ads/google_ads/google_ads_client.rb
+++ b/lib/google/ads/google_ads/google_ads_client.rb
@@ -225,7 +225,6 @@ module Google
         # Provides a Google::Auth::Credentials initialized with a keyfile
         # specified in the config.
         def get_service_account_credentials
-          raise 'config.impersonate required if keyfile specified' unless @config.impersonate
           keyfile = File.read(@config.keyfile)
           keyfile = JSON.parse(keyfile)
           Signet::OAuth2::Client.new(

--- a/test/test_google_ads_client.rb
+++ b/test/test_google_ads_client.rb
@@ -233,12 +233,14 @@ class TestGoogleAdsClient < Minitest::Test
   #   end
   # end
 
-  def test_keyfile_without_impersonate_raises
+  def test_crendetials_work_with_service_account_keyfile
     client = Google::Ads::GoogleAds::GoogleAdsClient.new do |config|
-      config.keyfile = 'keyfile'
+      config.keyfile = 'test/fixtures/keyfile.json'
     end
 
-    assert_raises do
+    assert_raises(OpenSSL::PKey::RSAError) do
+      # OpenSSL::PKey::RSAError means it read the test file and tried to
+      # initialize a key with it. Since it's not a valid key, it raises.
       client.get_credentials
     end
   end


### PR DESCRIPTION
Removes a check we for the `impersonate` field in order to make it work as expected: By only settings the `keyfile` field.