### PR TITLE
Fix support for Ruby 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ See the [Logging guide][].
 
 ## Ruby versions
 
-The client library supports versions 3.1, 3.2, and 3.3 of Ruby. We plan to
+The client library supports versions 3.2, 3.3, and 3.4 of Ruby. We plan to
 support three Ruby releases at any one time. As Ruby releases once a year on
 December 25th, we will look at dropping support for the oldest version early in
 the following year.

--- a/google-ads-googleads.gemspec
+++ b/google-ads-googleads.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0.0'
   s.summary = 'Google client library for the Google Ads API'
 
-  s.add_dependency 'gapic-common', ['>= 0.25', '< 1.0']
-  s.add_dependency 'google-protobuf', ['>= 3.19.4', '< 4.0']
+  s.add_dependency 'gapic-common', ['>= 0.25', '< 2.0']
+  s.add_dependency 'google-protobuf', ['>= 3.19.4', '< 5.0']
 
   s.add_development_dependency 'bundler', ["> 1.9", "< 3"]
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
**Problem**

`google-ads-ruby` cannot be installed when using Ruby 3.4.x. This is due to the locking of the upper bound version of `google-protobuf` dependency to `< 4.0.0` and `gapic-common` dependency to `< 1.0.0`. 

**Solution**

Bump the upper bound version lock of both of the aforementioned dependencies one major version, thus allowing for `>= 4.0.0` of `google-protobuf` and `>= 1.0.0` of `gapic-common`.

- Unlock gapic-common from < 1.0.0 to < 2.0.0.
- Unlock google-protobuf from < 4.0.0 to < 5.0.0.
  - google-protobuf 4.0.0 is required for Ruby 3.4 compatibility.

Resolves https://github.com/googleads/google-ads-ruby/issues/502

**Tophatting**

Before (Ruby 3.3.x installs fine, Ruby 3.4.x fails to install)

![Screenshot From 2025-05-09 08-41-14](https://github.com/user-attachments/assets/8b662cfd-06cd-41ab-a4ce-5e10063fa1b5)
![Screenshot From 2025-05-09 08-41-38](https://github.com/user-attachments/assets/05b3e477-a540-4059-85d3-428dbd87431a)
![Screenshot From 2025-05-09 08-41-44](https://github.com/user-attachments/assets/49669d15-dc11-46cd-baef-ded6744def87)

After (Ruby 3.4.x installs fine, using this branched version)

![Screenshot From 2025-05-09 08-54-07](https://github.com/user-attachments/assets/53f69a2c-ef8e-4da2-8686-3f78746b9231)

Testing - Simply ran the tests in this repo via `bundle exec rake test`.

![Screenshot From 2025-05-09 08-59-32](https://github.com/user-attachments/assets/dd970883-20ff-4240-a95f-732a6662e84d)

Notes

- I no longer have a production application I can test this change against. If someone does have an application with a solid test suite they can run this change against or perhaps toss this on a staging application or otherwise, that would be very helpful.

- If you look closely during my testing above there's a small working directory diff. That's simply me commenting out the `allocation_tracker` gem as it no longer installs properly. Seems like such has been an issue for close to 9 months now: https://github.com/ko1/allocation_tracer/issues/19.

![Screenshot From 2025-05-09 08-57-47](https://github.com/user-attachments/assets/d665b60f-7b0b-468b-bf60-efe3e063116b)