### PR TITLE
Bump activesupport requirement from 6.1 to 7.1 as the former is EOL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'pry', '~> 0.14.1'
 gem 'google-adwords-api', '~> 1.5'
 
 # used for the factories generator
-gem 'activesupport', '~> 6.1'
+gem 'activesupport', '~> 7.1'
 gem 'rspec', '~> 3.6'
 gem 'standard'
 gem 'allocation_tracer'


### PR DESCRIPTION
While working on https://github.com/googleads/google-ads-ruby/pull/515 I came across this message in my terminal while running tests.

```console
/home/larouxn/.gem/ruby/3.4.3/gems/activesupport-6.1.7.10/lib/active_support/core_ext/benchmark.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

At first I thought we needed to do something with the `benchmark` gem but that's when I realized this gem is still only requiring `~> 6.1` of `activesupport`. Support for 6.1 ended about 7 months ago. Thus, I'm proposing we raise the minimum requirement to 7.1, which is still supported for the next almost 5 months. ([EOL info](https://endoflife.date/rails))

Testing

![Screenshot From 2025-05-09 09-05-19](https://github.com/user-attachments/assets/b9a6b503-6f41-4ff0-b32d-340dea712f74)
