### PR TITLE
Updating version and CHANGELOG in preparation for minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+34.1.0
+-----
+ - Update activesupport version to 7.1
+ - Increase upper bound for google-protobuf and gapic-common dependencies
+
 34.0.0
 -----
  - Compatibility with v20 of the API: https://developers.google.com/google-ads/api/docs/release-notes

--- a/lib/google/ads/google_ads/version.rb
+++ b/lib/google/ads/google_ads/version.rb
@@ -20,7 +20,7 @@ module Google
   module Ads
     module GoogleAds
       CLIENT_LIB_NAME = 'gccl'.freeze
-      CLIENT_LIB_VERSION = '34.0.0'.freeze
+      CLIENT_LIB_VERSION = '34.1.0'.freeze
       VERSION = CLIENT_LIB_VERSION
     end
   end


### PR DESCRIPTION
Change-Id: I8cdd10edabd8b4770af0e9057275ae5e252c93bb

These changes are needed to create a release for [PR#515](https://github.com/googleads/google-ads-ruby/pull/515) and [PR#517](https://github.com/googleads/google-ads-ruby/pull/517)