### PR TITLE
fix: pass headers as initial metadata to work around gRPC bug 

### DIFF
--- a/lib/google/ads/google_ads/interceptors/metadata_interceptor.rb
+++ b/lib/google/ads/google_ads/interceptors/metadata_interceptor.rb
@@ -62,7 +62,7 @@ module Google
             # Here we can directly access it.
             if metadata.key?(:"x-goog-api-client")
               if @ads_assistant
-                 metadata[:"x-goog-api-client"] += " gaada/#{@ads_assistant}"
+                metadata[:"x-goog-api-client"] += " gaada/#{@ads_assistant}"
               end
 
               # Check if "pb" is already in the header

--- a/lib/google/ads/google_ads/service_lookup.rb
+++ b/lib/google/ads/google_ads/service_lookup.rb
@@ -71,16 +71,29 @@ module Google
           }
         end
 
+        # Workaround for gRPC Ruby bug (grpc/grpc#22448):
+        # When gapic-common calls gRPC with `return_op: true`,
+        # merge_metadata_to_send runs before interceptors execute,
+        # so MetadataInterceptor's metadata changes are silently dropped.
+        # Pass headers as initial metadata here until the upstream fix
+        # (grpc/grpc#42073) is released.
         def headers
+          h = {}
           if config.login_customer_id
             validate_customer_id(:login_customer_id)
+            h[:"login-customer-id"] = config.login_customer_id.to_s
           end
 
           if config.linked_customer_id
             validate_customer_id(:linked_customer_id)
+            h[:"linked-customer-id"] = config.linked_customer_id.to_s
           end
 
-          {}
+          unless config.use_cloud_org_for_api_access
+            h[:"developer-token"] = config.developer_token if config.developer_token
+          end
+
+          h
         end
 
         def validate_customer_id(field)

--- a/test/test_service_lookup.rb
+++ b/test/test_service_lookup.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# Encoding: utf-8
+
+require 'minitest/autorun'
+require 'google/ads/google_ads/service_lookup'
+require 'google/ads/google_ads/config'
+
+class TestServiceLookup < Minitest::Test
+  def create_lookup(config)
+    Google::Ads::GoogleAds::ServiceLookup.new(
+      nil,    # lookup_util
+      nil,    # logger
+      config,
+      nil,    # credentials_or_channel
+      nil,    # endpoint
+      nil     # deprecator
+    )
+  end
+
+  def test_headers_returns_empty_hash_when_nothing_set
+    config = Google::Ads::GoogleAds::Config.new
+    lookup = create_lookup(config)
+
+    assert_equal({}, lookup.send(:headers))
+  end
+
+  def test_headers_includes_all_when_fully_configured
+    config = Google::Ads::GoogleAds::Config.new do |c|
+      c.login_customer_id = 1234567890
+      c.linked_customer_id = 9876543210
+      c.developer_token = "test-dev-token"
+    end
+    lookup = create_lookup(config)
+
+    headers = lookup.send(:headers)
+    assert_equal "1234567890", headers[:"login-customer-id"]
+    assert_equal "9876543210", headers[:"linked-customer-id"]
+    assert_equal "test-dev-token", headers[:"developer-token"]
+  end
+
+  def test_headers_excludes_developer_token_when_cloud_org
+    config = Google::Ads::GoogleAds::Config.new do |c|
+      c.developer_token = "test-dev-token"
+      c.use_cloud_org_for_api_access = true
+    end
+    lookup = create_lookup(config)
+
+    headers = lookup.send(:headers)
+    assert_nil headers[:"developer-token"]
+  end
+end


### PR DESCRIPTION
Fixes #544

## Summary
- Work around gRPC Ruby bug (grpc/grpc#22448) where interceptor metadata changes are silently dropped when `return_op: true` is used
- Return `developer-token`, `login-customer-id`, and `linked-customer-id` from `ServiceLookup#headers` as initial metadata instead of relying solely on `MetadataInterceptor`
- Fix minor indentation in `MetadataInterceptor` (unrelated cleanup)

## Details
`gapic-common` calls gRPC with `return_op: true`, which causes `merge_metadata_to_send` to run before interceptors execute. This means `MetadataInterceptor`'s metadata modifications are lost, resulting in `DEVELOPER_TOKEN_PARAMETER_MISSING` errors.

This change passes the headers via gax's `metadata` option (set at client initialization), which bypasses the interceptor ordering issue. `MetadataInterceptor` is kept as-is for backward compatibility and can be cleaned up once the upstream fix (grpc/grpc#42073) is released.